### PR TITLE
Native Separators and "ArrowsAlwaysVisible" on NativeSlidableItems

### DIFF
--- a/LemonUI.FiveM/LemonUI.FiveM.csproj
+++ b/LemonUI.FiveM/LemonUI.FiveM.csproj
@@ -33,6 +33,9 @@
       <IncludeAssets>compile</IncludeAssets>
     </PackageReference>
     <Compile Include="$(ProjectDir)/../LemonUI/**" />
+    <Compile Update="..\LemonUI\Menus\NativeSeparatorItem.cs">
+      <Link>Menus\NativeSeparatorItem.cs</Link>
+    </Compile>
   </ItemGroup>
 
 </Project>

--- a/LemonUI/Menus/NativeItem.cs
+++ b/LemonUI/Menus/NativeItem.cs
@@ -111,7 +111,7 @@ namespace LemonUI.Menus
                 Recalculate();
             }
         }
-
+        
         #endregion
 
         #region Events

--- a/LemonUI/Menus/NativeSeparatorItem.cs
+++ b/LemonUI/Menus/NativeSeparatorItem.cs
@@ -1,0 +1,15 @@
+﻿namespace LemonUI.Menus
+{
+    /// <summary>
+    /// A blank separator item for dividing menus.
+    /// </summary>
+    public class NativeSeparatorItem: NativeItem
+    {
+        /// <summary>
+        /// Creates a new NativeSeparator
+        /// </summary>
+        public NativeSeparatorItem() : base("", "", "")
+        {
+        }
+    }
+}

--- a/LemonUI/Menus/NativeSlidableItem.cs
+++ b/LemonUI/Menus/NativeSlidableItem.cs
@@ -20,6 +20,16 @@ namespace LemonUI.Menus
         internal protected ScaledTexture arrowRight = null;
 
         #endregion
+        
+        #region Public Properties
+
+        /// <summary>
+        /// Whether the arrows should always be shown regardless of state.
+        /// </summary>
+        public bool ArrowsAlwaysVisible = false;
+
+        #endregion
+        
 
         #region Constructors
 
@@ -54,8 +64,8 @@ namespace LemonUI.Menus
         {
             base.Recalculate(pos, size, selected);
             // Set the sizes of the arrows
-            arrowLeft.Size = selected && Enabled ? new SizeF(30, 30) : SizeF.Empty;
-            arrowRight.Size = selected && Enabled ? new SizeF(30, 30) : SizeF.Empty;
+            arrowLeft.Size = (selected && Enabled) || ArrowsAlwaysVisible ? new SizeF(30, 30) : SizeF.Empty;
+            arrowRight.Size = (selected && Enabled) || ArrowsAlwaysVisible ? new SizeF(30, 30) : SizeF.Empty;
             // And set the positions of the right arrow
             arrowRight.Position = new PointF(pos.X + size.Width - arrowRight.Size.Width - 5, pos.Y + 4);
         }


### PR DESCRIPTION
The title says it all, added native separators and "ArrowsAlwaysVisible" field to the NativeSlidableItems (to hopefully make it easier if anyone wishes to make their own HeritageSliderItem).