### PR TITLE
Add NativeListItem.ItemAdded #180

### DIFF
--- a/LemonUI/Menus/ItemModifiedEventArgs.cs
+++ b/LemonUI/Menus/ItemModifiedEventArgs.cs
@@ -1,0 +1,38 @@
+namespace LemonUI.Menus
+{
+    /// <summary>
+    /// Represents the addition or removal of an item in a list.
+    /// </summary>
+    /// <typeparam name="T">The type of object that was modified.</typeparam>
+    public class ItemModifiedEventArgs<T>
+    {
+        #region Properties
+
+        /// <summary>
+        /// The item that was added or removed.
+        /// </summary>
+        public T Item { get; }
+        
+        /// <summary>
+        /// The position where the item was added or removed.
+        /// </summary>
+        public int Position { get; }
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Creates a new instance of <see cref="ItemModifiedEventArgs{T}"/>.
+        /// </summary>
+        /// <param name="item">The item that was added or removed.</param>
+        /// <param name="position">The position where the item was added or removed.</param>
+        public ItemModifiedEventArgs(T item, int position)
+        {
+            Item = item;
+            Position = position;
+        }
+
+        #endregion
+    }
+}

--- a/LemonUI/Menus/ItemModifiedEventHandler.cs
+++ b/LemonUI/Menus/ItemModifiedEventHandler.cs
@@ -1,0 +1,10 @@
+namespace LemonUI.Menus
+{
+    /// <summary>
+    /// Represents the method that is called when an item is added to or removed from a List Item.
+    /// </summary>
+    /// <typeparam name="T">The type of item that was modified.</typeparam>
+    /// <param name="sender">The source of the event.</param>
+    /// <param name="e">A <see cref="ItemModifiedEventArgs{T}"/> with the information of the modified item.</param>
+    public delegate void ItemModifiedEventHandler<T>(object sender, ItemModifiedEventArgs<T> e);
+}

--- a/LemonUI/Menus/NativeListItem{T}.cs
+++ b/LemonUI/Menus/NativeListItem{T}.cs
@@ -103,6 +103,16 @@ namespace LemonUI.Menus
         /// Event triggered when the selected item is changed.
         /// </summary>
         public event ItemChangedEventHandler<T> ItemChanged;
+        
+        /// <summary>
+        /// Event triggered when an item is added to the list.
+        /// </summary>
+        public event ItemModifiedEventHandler<T> ItemAdded;
+        
+        /// <summary>
+        /// Event triggered when an item is removed from the list.
+        /// </summary>
+        public event ItemModifiedEventHandler<T> ItemRemoved;
 
         #endregion
 
@@ -202,18 +212,30 @@ namespace LemonUI.Menus
             {
                 UpdateIndex();
             }
+            
+            // Trigger the ItemAdded event
+            ItemAdded?.Invoke(this, new ItemModifiedEventArgs<T>(item, position));
         }
+        
         /// <summary>
         /// Removes a specific <typeparamref name="T" />.
         /// </summary>
         /// <param name="item">The <typeparamref name="T" /> to remove.</param>
         public void Remove(T item)
         {
-            if (items.Remove(item))
+            int position = items.IndexOf(item);
+            if (position >= 0)
             {
-                FixIndexIfRequired();
+                T removedItem = items[position];
+                if (items.Remove(item))
+                {
+                    FixIndexIfRequired();
+                    // Trigger the ItemRemoved event
+                    ItemRemoved?.Invoke(this, new ItemModifiedEventArgs<T>(removedItem, position));
+                }
             }
         }
+        
         /// <summary>
         /// Removes a <typeparamref name="T" /> at a specific location.
         /// </summary>
@@ -224,11 +246,16 @@ namespace LemonUI.Menus
             {
                 return;
             }
-
+            
+            T removedItem = items[position];
             items.RemoveAt(position);
             FixIndexIfRequired();
             UpdateIndex();
+            
+            // Trigger the ItemRemoved event
+            ItemRemoved?.Invoke(this, new ItemModifiedEventArgs<T>(removedItem, position));
         }
+        
         /// <summary>
         /// Removes all of the items that match the <paramref name="pred"/>.
         /// </summary>


### PR DESCRIPTION
# What feature or bug fix this being introduced?

Adds NativeListItem.ItemAdded and NativeListItem.ItemRemove which get triggered respectively when and item is added or removed from a list. Allows for UI elements to update when items are added or removed.




# What does this fix/feature accomplishes?
Feature request for #180 